### PR TITLE
Update to make use of packagist metadata v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Usage
 It's unlikely that this will work for anyone but me, but the basic usage is:
 
 ```sh
+composer install
+
 # Clone top 2k packages into repos/ (~20GB):
 php download.php 0 2000
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "composer/metadata-minifier": "^1.0"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,88 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "0033993c59b2d94fdee21a64365a45d0",
+    "packages": [
+        {
+            "name": "composer/metadata-minifier",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/metadata-minifier.git",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/metadata-minifier/zipball/c549d23829536f0d0e984aaabbf02af91f443207",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2",
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\MetadataMinifier\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Small utility library that handles metadata minification and expansion.",
+            "keywords": [
+                "composer",
+                "compression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/metadata-minifier/issues",
+                "source": "https://github.com/composer/metadata-minifier/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-07T13:37:33+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/download.php
+++ b/download.php
@@ -1,12 +1,14 @@
 <?php error_reporting(E_ALL);
 
-function getTopPackages($min, $max) {
-    $perPage = 15;
+require 'vendor/autoload.php';
+
+function getTopPackages(int $min, int $max) {
+    $perPage = max(1, min($max - $min, 100));
     $page = intdiv($min, $perPage);
     $id = $page * $perPage;
     while (true) {
         $page++;
-        $url = 'https://packagist.org/explore/popular.json?page=' . $page;
+        $url = 'https://packagist.org/explore/popular.json?page=' . $page.'&per_page='.$perPage;
         $json = json_decode(file_get_contents($url), true);
         foreach ($json['packages'] as $package) {
             yield $id => $package['name'];
@@ -31,21 +33,38 @@ $maxPackage = $argv[2];
 foreach (getTopPackages($minPackage, $maxPackage) as $i => $packageName) {
     echo "[$i] $packageName\n";
     $packageName = strtolower($packageName);
-    $url = 'https://repo.packagist.org/p/' . $packageName . '.json';
+    $url = 'https://repo.packagist.org/p2/' . $packageName . '~dev.json';
     $json = json_decode(file_get_contents($url), true);
-    $versions = $json['packages'][$packageName];
-    if (isset($versions['dev-master'])) {
-        $version = 'dev-master';
-    } else {
-        // Pick last version.
-        $keys = array_keys($versions);
-        $version = $keys[count($keys) - 1];
+    $versions = \Composer\MetadataMinifier\MetadataMinifier::expand($json['packages'][$packageName]);
+    unset($package);
+    // select default branch if available
+    foreach ($versions as $version) {
+        if (true === ($version['default-branch'] ?? false)) {
+            $package = $version;
+            break;
+        }
+    }
+    if (!isset($package)) {
+        // or any branch
+        if (count($versions) > 0) {
+            $package = reset($versions);
+        } else {
+            // or any version
+            $url = 'https://repo.packagist.org/p2/' . $packageName . '~dev.json';
+            $json = json_decode(file_get_contents($url), true);
+            $versions = \Composer\MetadataMinifier\MetadataMinifier::expand($json['packages'][$packageName]);
+            if (count($versions) > 0) {
+                $package = reset($versions);
+            } else {
+                echo "Skipping due to no version found\n";
+                continue;
+            }
+        }
     }
 
     // Thanks to people excluding tests from dist packages,
     // we're forced to clone source repos here.
-    $package = $versions[$version];
-    if ($package['source'] === null) {
+    if (($package['source'] ?? null) === null) {
         echo "Skipping due to missing source\n";
         continue;
     }
@@ -57,7 +76,7 @@ foreach (getTopPackages($minPackage, $maxPackage) as $i => $packageName) {
     $git = $package['source']['url'];
     $repo = __DIR__ . '/repos/' . $packageName;
     if (!is_dir($repo)) {
-        echo "Cloning $packageName @ $version from $git...\n";
+        echo "Cloning $packageName @ {$package['version']} from $git...\n";
         exec("git clone $git $repo", $execOutput, $execRetval);
         if ($execRetval !== 0) {
             echo "git clone failed: $execOutput\n";


### PR DESCRIPTION
The v1 metadata is readonly as of Feb 1st 2025, this fixes it to use v2, and it improves the default branch detection as a bonus :)

@nikic I hope you can merge this as I believe others rely on this repo every now and then if only to download stuff and grep things.